### PR TITLE
capybaraのテスト実行環境をselunium_driverに変更

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
---require spec_helper
+--require rails_helper
 --format documentation

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'ancestry'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'rspec-rails'
+  gem 'rspec-rails', '>= 4.0.2'
   gem 'rails-controller-testing'
   gem 'factory_bot_rails'
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -359,10 +359,10 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-rails (4.0.2)
-      actionpack (>= 4.2)
-      activesupport (>= 4.2)
-      railties (>= 4.2)
+    rspec-rails (5.0.1)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      railties (>= 5.2)
       rspec-core (~> 3.10)
       rspec-expectations (~> 3.10)
       rspec-mocks (~> 3.10)
@@ -488,7 +488,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-erd
   rails-i18n
-  rspec-rails
+  rspec-rails (>= 4.0.2)
   rubocop-airbnb
   sass-rails (>= 6)
   selenium-webdriver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,13 @@ services:
       - "3000:3000"
     depends_on:
       - db
+      - chrome
     stdin_open: true
     tty: true
+  chrome:
+    image: selenium/standalone-chrome:latest
+    ports:
+     - 4444:4444
 volumes:
   mysql-data:
     driver: local

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -31,7 +31,31 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+Capybara.register_driver :remote_chrome do |app|
+  url = "http://chrome:4444/wd/hub"
+  caps = ::Selenium::WebDriver::Remote::Capabilities.chrome(
+    "goog:chromeOptions" => {
+      "args" => [
+        "no-sandbox",
+        "headless",
+        "disable-gpu",
+        "window-size=1680,1050",
+      ],
+    }
+  )
+  Capybara::Selenium::Driver.new(app, browser: :remote, url: url, desired_capabilities: caps)
+end
 RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by :remote_chrome
+    Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
+    Capybara.server_port = 3000
+    Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
+  end
   config.include FactoryBot::Syntax::Methods
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/system/confirm_notifications_spec.rb
+++ b/spec/system/confirm_notifications_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper.rb'
 
 RSpec.describe "Confirm notification", type: :system do
-  before { driven_by(:rack_test) }
-
   let(:user) { create(:user) }
   let(:second_user) { create(:user) }
   let(:third_user) { create(:user) }

--- a/spec/system/site_layouts_spec.rb
+++ b/spec/system/site_layouts_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Layouts', type: :system do
-  before do
-    driven_by(:rack_test)
-  end
-
   let(:user) { create(:user) }
 
   context "user dont sign in" do

--- a/spec/system/users/user_edit_spec.rb
+++ b/spec/system/users/user_edit_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'User edit imformation', type: :system do
-  before do
-    driven_by(:rack_test)
-  end
-
   context "change user profile imformation" do
     let(:user) { create(:user) }
     let(:changed_name) { "changed_name" }

--- a/spec/system/users/user_following_spec.rb
+++ b/spec/system/users/user_following_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'User following', type: :system do
-  before do
-    driven_by(:rack_test)
-  end
-
   describe "View rendering test" do
     let!(:user) { create(:user) }
     let!(:users) { create_list(:user, 21) }

--- a/spec/system/users/user_signin_spec.rb
+++ b/spec/system/users/user_signin_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'User signin', type: :system do
-  before do
-    driven_by(:rack_test)
-  end
-
   let!(:user) { create(:user) }
 
   context "user has valid signin imformation" do

--- a/spec/system/users/user_signup_spec.rb
+++ b/spec/system/users/user_signup_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 RSpec.describe 'User signup', type: :system do
   subject { User.find_by(email: email) }
 
-  before do
-    driven_by(:rack_test)
-  end
-
   let!(:user) { build(:user) }
 
   context "user has valid imformation" do

--- a/spec/system/users/users_profile_spec.rb
+++ b/spec/system/users/users_profile_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Users profile', type: :system do
-  before do
-    driven_by(:rack_test)
-  end
-
   describe "User profile test" do
     let!(:user) { create(:user) }
     let!(:works) { create_list(:work, 21, user: user) }

--- a/spec/system/works/commented_work_spec.rb
+++ b/spec/system/works/commented_work_spec.rb
@@ -1,10 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Commented work", type: :system do
-  before do
-    driven_by(:rack_test)
-  end
-
   let(:user) { create(:user) }
   let(:another_user) { create(:user) }
   let(:work) { create(:work, user: user) }

--- a/spec/system/works/liked_work_spec.rb
+++ b/spec/system/works/liked_work_spec.rb
@@ -1,10 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Liked work", type: :system do
-  before do
-    driven_by(:rack_test)
-  end
-
   let(:user) { create(:user) }
   let(:another_user) { create(:user) }
   let(:work) { create(:work, user: user) }

--- a/spec/system/works/search_work_spec.rb
+++ b/spec/system/works/search_work_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Search work", type: :system do
-  before { driven_by(:rack_test) }
-
   let(:keyword) { "keyword" }
   let!(:work_with_title) { create(:work, title: keyword) }
   let!(:work_with_concept) { create(:work, concept: keyword) }

--- a/spec/system/works/works_interface_spec.rb
+++ b/spec/system/works/works_interface_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Works interface', type: :system do
-  before do
-    driven_by(:rack_test)
-  end
-
   let(:user) { create(:user) }
   let!(:works) { create_list(:work, 21, user: user) }
   let!(:current_work) { works[20] }


### PR DESCRIPTION
docker-composeにchromeコンテナを導入し、rspecのテスト実行環境をseluniumとなるよう設定を変更した。
現状では、まだJSの動作を確認できていない。
ただ、これまでエラーが発生せぬよう、system_specのテスト実行時にrack_testを指定していた為、その部分を削除するという大幅なリファクタリングに繋がった。