### PR TITLE
削除操作の統合テストの追加

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -41,7 +41,7 @@ class WorksController < ApplicationController
   def destroy
     @work.destroy
     flash[:success] = "削除しました。"
-    redirect_back(fallback_location: root_url)
+    redirect_to root_url
   end
 
   def index

--- a/spec/system/users/user_edit_spec.rb
+++ b/spec/system/users/user_edit_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe 'User edit imformation', type: :system do
+RSpec.describe 'User edit imformation', type: :system, js: true do
+  let(:user) { create(:user) }
+
   context "change user profile imformation" do
-    let(:user) { create(:user) }
     let(:changed_name) { "changed_name" }
     let(:changed_website) { "https://example/example" }
     let(:changed_description) { "changed_description" }
@@ -10,6 +11,10 @@ RSpec.describe 'User edit imformation', type: :system do
     it "changed success" do
       sign_in user
       visit root_path
+      within("li.dropdown") do
+        expect(page).to have_link class: "dropdown-toggle"
+        click_on "#{user.username}"
+      end
       click_link "アカウント編集"
       expect(current_path).to eq edit_user_registration_path
       within("#edit_user") do
@@ -32,7 +37,6 @@ RSpec.describe 'User edit imformation', type: :system do
   end
 
   context "change user password" do
-    let(:user) { create(:user) }
     let(:current_password) { "#{user.password}" }
     let(:new_password) { "newpassword" }
     let(:wrong_password) { "wrongpassword" }
@@ -40,6 +44,10 @@ RSpec.describe 'User edit imformation', type: :system do
     it "changed success" do
       sign_in user
       visit root_path
+      within("li.dropdown") do
+        expect(page).to have_link class: "dropdown-toggle"
+        click_on "#{user.username}"
+      end
       click_link "アカウント編集"
       click_link "パスワードを変更する"
       expect(current_path).to eq edit_password_path
@@ -58,6 +66,10 @@ RSpec.describe 'User edit imformation', type: :system do
     it "changed false" do
       sign_in user
       visit root_path
+      within("li.dropdown") do
+        expect(page).to have_link class: "dropdown-toggle"
+        click_on "#{user.username}"
+      end
       click_link "アカウント編集"
       click_link "パスワードを変更する"
       expect(current_path).to eq edit_password_path
@@ -71,6 +83,27 @@ RSpec.describe 'User edit imformation', type: :system do
       expect(page).to have_selector ".error_explanation"
       visit current_path
       expect(page).not_to have_selector ".error_explanation"
+    end
+  end
+
+  context "delete user account" do
+    it "delete success" do
+      sign_in user
+      visit root_path
+      within("li.dropdown") do
+        expect(page).to have_link class: "dropdown-toggle"
+        click_on "#{user.username}"
+      end
+      click_link "アカウント編集"
+      within(".form--common") do
+        page.accept_confirm do
+          click_on "アカウントを削除する"
+        end
+      end
+      expect(current_path).to eq root_path
+      expect(page).to have_selector "p.success"
+      visit current_path
+      expect(page).not_to have_selector "p.success"
     end
   end
 end

--- a/spec/system/users/user_following_spec.rb
+++ b/spec/system/users/user_following_spec.rb
@@ -1,15 +1,13 @@
 require 'rails_helper'
 
-RSpec.describe 'User following', type: :system do
+RSpec.describe 'User following', type: :system, js: true do
   describe "View rendering test" do
     let!(:user) { create(:user) }
     let!(:users) { create_list(:user, 21) }
     let(:users_in_page) { users.take(20) }
 
     context "get following view" do
-      before do
-        users.each { |member| user.follow(member) }
-      end
+      before { users.each { |member| user.follow(member) } }
 
       it "rendering following member correctly" do
         sign_in user
@@ -27,9 +25,7 @@ RSpec.describe 'User following', type: :system do
     end
 
     context "get follower view" do
-      before do
-        users.each { |member| member.follow(user) }
-      end
+      before { users.each { |member| member.follow(user) } }
 
       it "rendering followers member correctly" do
         sign_in user
@@ -61,7 +57,9 @@ RSpec.describe 'User following', type: :system do
       expect(current_path).to eq user_path another_user
       expect(user.following.count).to eq following + 1
       within(".follow_form") do
-        click_button "フォロー中"
+        page.accept_confirm do
+          click_button "フォロー中"
+        end
       end
       expect(current_path).to eq user_path another_user
       expect(user.following.count).to eq following

--- a/spec/system/works/commented_work_spec.rb
+++ b/spec/system/works/commented_work_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Commented work", type: :system do
+RSpec.describe "Commented work", type: :system, js: true do
   let(:user) { create(:user) }
   let(:another_user) { create(:user) }
   let(:work) { create(:work, user: user) }
@@ -34,7 +34,9 @@ RSpec.describe "Commented work", type: :system do
     expect(page).not_to have_selector "p.success"
     within(".comments_to_work__aside") do
       within("li#comment-#{current_comment.id}") do
-        click_link "削除"
+        page.accept_confirm do
+          click_on "削除"
+        end
       end
     end
     expect(page).to have_selector "p.success"

--- a/spec/system/works/create_work_spec.rb
+++ b/spec/system/works/create_work_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "Create or delete work", type: :system, js: true do
+  let(:user) { create(:user) }
+  let(:work) { create(:work, user_id: user.id) }
+
+  it "delete work" do
+    sign_in user
+    visit work_path work
+    within(".work--settings") do
+      expect(page).to have_selector "span.delete_btn"
+      page.accept_confirm do
+        click_link "削除する"
+      end
+    end
+  end
+end


### PR DESCRIPTION
RSpecでDOM操作が可能になったことを受け、ユーザーや作品などのインスタンスの削除を行う、以下の統合テストを追加した。
1. ユーザーの削除
2. 作品の削除
3. コメントの削除
4. フォローの解除
削除のテストを追加することで、ユーザーの利用に近い操作のチェックを行った。
