### PR TITLE
作品にイラストの追加と作品の登録の失敗に関する統合テストの追加

### DIFF
--- a/spec/system/works/create_work_spec.rb
+++ b/spec/system/works/create_work_spec.rb
@@ -4,21 +4,24 @@ RSpec.describe "Create or delete work", type: :system, js: true do
   let(:user) { create(:user) }
 
   context "create work" do
+    before do
+      sign_in user
+      visit root_path
+      within("li.dropdown") do
+        click_on "#{user.username}"
+      end
+      click_link "新規作品"
+    end
+
     let!(:parent_category) { create(:category, name: "child_category", ancestry: nil) }
     let!(:child_category) { create(:category, name: "parent_category", ancestry: parent_category.id) }
     let(:title) { "This is title" }
     let(:concept) { "This is concept" }
     let(:description) { "This is description" }
+    let(:illustration_name) { "This is illustration_name" }
+    let(:illustration_description) { "This is illustration_description" }
     let(:image_path) { File.join(Rails.root, "spec/fixture/files/test.jpeg") }
     it "created successfully" do
-      sign_in user
-      visit root_path
-      within("li.dropdown") do
-        expect(page).to have_link class: "dropdown-toggle"
-        click_on "#{user.username}"
-      end
-      click_link "新規作品"
-      expect(current_path).to eq new_work_path
       within(".form--create_work") do
         fill_in "作品タイトル", with: title
         find("option[value='#{parent_category.id}']").select_option
@@ -29,6 +32,9 @@ RSpec.describe "Create or delete work", type: :system, js: true do
         expect(page).to have_selector "img[alt='preview']"
         fill_in "コンセプト", with: concept
         fill_in "作品説明", with: description
+        fill_in "work_create_illustrations_attributes_0_name", with: illustration_name
+        fill_in "work_create_illustrations_attributes_0_description", with: illustration_description
+        attach_file('work_create[illustrations_attributes][0][photo]', image_path, make_visible: true)
         click_button "登録する"
       end
       expect(page).to have_selector "p.success"
@@ -39,8 +45,43 @@ RSpec.describe "Create or delete work", type: :system, js: true do
         expect(page).to have_selector "p", text: "#{concept}"
         expect(page).to have_selector "p", text: "#{description}"
       end
+      within("li.illustration--info") do
+        expect(page).to have_selector "img[src$='test.jpeg']"
+        expect(page).to have_selector "span.name", text: "#{illustration_name}"
+        expect(page).to have_selector "span.description", text: "#{illustration_description}"
+      end
       visit current_path
       expect(page).not_to have_selector "p.success"
+    end
+
+    it "created in failure because category isn't selected" do
+      within(".form--create_work") do
+        fill_in "作品タイトル", with: title
+        fill_in "コンセプト", with: concept
+        attach_file('work_create[image]', image_path, make_visible: true)
+        expect(page).to have_selector "img[alt='preview']"
+        click_button "登録する"
+      end
+      within(".error_explanation") do
+        expect(all('li').size).to eq(1)
+        expect(page).to have_selector "li", text: "カテゴリーを入力してください"
+      end
+    end
+
+    it "created in failure because a image isn't attached" do
+      within(".form--create_work") do
+        fill_in "作品タイトル", with: title
+        fill_in "コンセプト", with: concept
+        find("option[value='#{parent_category.id}']").select_option
+        within(".category__child") do
+          find("option[value='#{child_category.id}']").select_option
+        end
+        click_button "登録する"
+      end
+      within(".error_explanation") do
+        expect(all('li').size).to eq(1)
+        expect(page).to have_selector "li", text: "メイン画像ファイルを添付してください。"
+      end
     end
   end
 


### PR DESCRIPTION
以下の要素の統合テストを追加した
1. 作品にイラストを追加
2. 作品のカテゴリー選択をしない場合に失敗するテスト
3. 作品の画像を追加しない場合に失敗するテスト

5MB以上の画像を添付した場合に発生する、JSのアラートに関するテストの追加を試みたが、画像の添付に関して失敗した。
このテストに関しては次回以降とする。