### PR TITLE
作品のいいね機能に関連するページを2つ追加

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,5 +1,13 @@
 class LikesController < ApplicationController
-  before_action :authenticate_user!, only: [:create, :destroy]
+  before_action :authenticate_user!
+  def index
+    @work = Work.find(params[:work_id])
+  end
+
+  def favorites
+    @user = User.find(params[:user_id])
+  end
+
   def create
     @liked = current_user.likes.create(work_id: params[:work_id])
     @work = Work.find_by(id: params[:work_id])

--- a/app/views/likes/favorites.html.erb
+++ b/app/views/likes/favorites.html.erb
@@ -1,0 +1,2 @@
+<% set_meta_tags title: "いいねした作品", site: "#{@user.username}" %>
+<h1>ここにいいねした作品を表示します</h1>

--- a/app/views/likes/index.html.erb
+++ b/app/views/likes/index.html.erb
@@ -1,0 +1,2 @@
+<% set_meta_tags title: "いいねしたユーザー", site: "#{@work.title}" %>
+<h1>ここにいいねしたユーザーを表示します</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,12 +14,13 @@ Rails.application.routes.draw do
   get  '/contact', to: 'static_pages#contact'
   get  '/tos', to: 'static_pages#terms', as: 'terms'
   resources :users, only: [:show, :index] do
+    resources :likes, only: :index, to: "likes#favorites"
     member do
       get :following, :followers
     end
   end
   resources :works do
-    resources :likes, only: [:create, :destroy]
+    resources :likes, only: [:create, :destroy, :index]
     collection do
       get 'get_category_children', defaults: { fomat: 'json' }
       get 'search', to: 'works#search'

--- a/spec/requests/likes_spec.rb
+++ b/spec/requests/likes_spec.rb
@@ -3,12 +3,61 @@ require 'rails_helper'
 RSpec.describe "Likes", type: :request do
   let!(:user) { create(:user) }
   let!(:work) { create(:work) }
+  describe "GET /users/:user_id/likes" do
+    let(:page_title) { "いいねした作品" }
+    context "user dosent sign in" do
+      before { get user_likes_path user }
+
+      it "redirect_to sign in view" do
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context "user signed in" do
+      before do
+        sign_in user
+        get user_likes_path user
+      end
+
+      it "render favorites" do
+        expect(response.status).to eq 200
+      end
+
+      it 'have page_title of title tag' do
+        expect(response.body).to match(/<title>#{page_title} | #{user.username}<\/title>/i)
+      end
+    end
+  end
+
+  describe "GET /works/:work_id/likes" do
+    let(:page_title) { "いいねしたユーザー" }
+    context "user dosent sign in" do
+      before { get work_likes_path work }
+
+      it "redirect_to sign in view" do
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context "user signed in" do
+      before do
+        sign_in user
+        get work_likes_path work
+      end
+
+      it "render index" do
+        expect(response.status).to eq 200
+      end
+
+      it 'have page_title of title tag' do
+        expect(response.body).to match(/<title>#{page_title} | #{work.title}<\/title>/i)
+      end
+    end
+  end
 
   describe "POST /works/:work_id/likes" do
     context "user dosent sign in" do
-      before do
-        post work_likes_path work
-      end
+      before { post work_likes_path work }
 
       it "redirect_to sign in view" do
         expect(response).to redirect_to new_user_session_path
@@ -30,9 +79,7 @@ RSpec.describe "Likes", type: :request do
   describe "DELETE /works/:work_id/likes/:id" do
     let(:like) { create(:like, user_id: user.id, work_id: work.id) }
     context "user dosent sign in" do
-      before do
-        delete work_like_path(work, like)
-      end
+      before { delete work_like_path(work, like) }
 
       it "redirect_to sign in view" do
         expect(response).to redirect_to new_user_session_path


### PR DESCRIPTION
TDDで新たなviewを下記の2つ追加した。
1. いいねしたユーザーを表示させるページ
2. いいねした作品を表示するページ

両ページのviewの装飾は次のissueで管理するものとし、ユーザーを表示させるページに関してはモーダル表示に対応させる。