### PR TITLE
いいねしてくれたユーザーを表示するページの整備

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,7 +1,11 @@
 class LikesController < ApplicationController
   before_action :authenticate_user!
   def index
-    @work = Work.find(params[:work_id])
+    @work = Work.includes(
+      [
+        likes: [user: [avatar_attachment: :blob]],
+      ]
+    ).find(params[:work_id])
   end
 
   def favorites

--- a/app/views/likes/_like.html.erb
+++ b/app/views/likes/_like.html.erb
@@ -12,5 +12,7 @@
   <% end %>
 <% end %>
 <span class="likes_count">
-  <%= work.likes.count %>
+  <%= link_to work_likes_path work do %>
+    <%= work.likes.count %>
+  <% end %>
 </span>

--- a/app/views/likes/index.html.erb
+++ b/app/views/likes/index.html.erb
@@ -1,2 +1,15 @@
 <% set_meta_tags title: "いいねしたユーザー", site: "#{@work.title}" %>
-<h1>ここにいいねしたユーザーを表示します</h1>
+<h2>いいねしたユーザー一覧</h2>
+<div class="row">
+  <div class="col-md-offset-3 col-md-6">
+    <% if @work.likes.present? %>
+      <ul class="users">
+        <% @work.likes.each do |like| %>
+          <%= render like.user %>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="center">いいねしたユーザーはいません</p>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
作品にいいねしてくれたユーザーの一覧を表示、またそのページのデザインを整備した。
気をつけた点
- ページの表示の際にN+1問題を生じさせない
- 部品化したユーザーのパーシャルを再利用
- このページへアクセスするリンクを追加