### PR TITLE
ユーザーがいいねした作品の一覧を表示する統合テストの追加

### DIFF
--- a/app/views/likes/favorites.html.erb
+++ b/app/views/likes/favorites.html.erb
@@ -26,7 +26,7 @@
       </div>
     </section>
     <section class="user--works">
-      <ul>
+      <ul class="user--works__types">
         <li><h2><%= link_to "作品一覧", user_path(@user) %></h2></li>
         <li><h2><%= link_to "いいね一覧", user_likes_path(@user) %></h2></li>
       </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -26,7 +26,7 @@
       </div>
     </section>
     <section class="user--works">
-      <ul>
+      <ul class="user--works__types">
         <li><h2><%= link_to "作品一覧", user_path(@user) %></h2></li>
         <li><h2><%= link_to "いいね一覧", user_likes_path(@user) %></h2></li>
       </ul>

--- a/spec/system/users/users_profile_spec.rb
+++ b/spec/system/users/users_profile_spec.rb
@@ -8,13 +8,17 @@ RSpec.describe 'Users profile', type: :system do
       sign_in user
     end
 
-    it "profile imformation display correctly" do
+    it "profile information display correctly" do
       visit user_path user
       within(".user--info") do
-        expect(page).to have_selector "img"
+        expect(page).to have_selector "img[alt='#{user.username}']"
         expect(page).to have_selector "h1", text: "#{user.username}"
       end
       within(".user--works") do
+        within("ul.user--works__types") do
+          expect(page).to have_link "作品一覧", href: user_path(user)
+          expect(page).to have_link "いいね一覧", href: user_likes_path(user)
+        end
         user.works.page(1) do |work|
           expect(page).to have_selector "img.avatar"
           expect(page).to have_selector ".user", text: "#{work.user.name}"

--- a/spec/system/works/liked_work_spec.rb
+++ b/spec/system/works/liked_work_spec.rb
@@ -62,4 +62,61 @@ RSpec.describe "Liked work", type: :system do
     expect(page).not_to have_selector "ul.users"
     expect(page).to have_selector "p.center", text: "いいねしたユーザーはいません"
   end
+
+  context "user had liked a work" do
+    it "display works user liked" do
+      sign_in another_user
+      visit user_path another_user
+      expect(current_path).to eq user_path another_user
+      within(".user--works") do
+        within("ul.user--works__types") do
+          expect(page).to have_link "作品一覧", href: user_path(another_user)
+          expect(page).to have_link "いいね一覧", href: user_likes_path(another_user)
+          click_link "いいね一覧"
+        end
+      end
+      expect(current_path).to eq user_likes_path another_user
+      within(".user--info") do
+        expect(page).to have_selector "img[alt='#{another_user.username}']"
+        expect(page).to have_selector "h1", text: "#{another_user.username}"
+      end
+      within("section.user--works") do
+        within("ul.user--works__types") do
+          expect(page).to have_link "作品一覧", href: user_path(another_user)
+          expect(page).to have_link "いいね一覧", href: user_likes_path(another_user)
+        end
+        within("ol.works") do
+          within("li#work-#{work.id}") do
+            expect(page).to have_link "#{work.title}", href: work_path(work)
+          end
+        end
+      end
+    end
+  end
+
+  context "user had not liked a work" do
+    it "display no works user liked" do
+      sign_in user
+      visit user_path user
+      within(".user--works") do
+        within("ul.user--works__types") do
+          expect(page).to have_link "作品一覧", href: user_path(user)
+          expect(page).to have_link "いいね一覧", href: user_likes_path(user)
+          click_link "いいね一覧"
+        end
+      end
+      expect(current_path).to eq user_likes_path user
+      within(".user--info") do
+        expect(page).to have_selector "img[alt='#{user.username}']"
+        expect(page).to have_selector "h1", text: "#{user.username}"
+      end
+      within("section.user--works") do
+        within("ul.user--works__types") do
+          expect(page).to have_link "作品一覧", href: user_path(user)
+          expect(page).to have_link "いいね一覧", href: user_likes_path(user)
+        end
+        expect(page).to have_selector "h4", text: "いいねした作品がありません"
+      end
+    end
+  end
 end


### PR DESCRIPTION
表題のテストを追加した。
また、ユーザーのプロフィール画面も変更に伴い、ユーザーのプロフィール画面の統合テストの正確性を増加させた。