### PR TITLE
足跡モデルの単体テストの追加

### DIFF
--- a/app/models/footprint.rb
+++ b/app/models/footprint.rb
@@ -1,5 +1,7 @@
 class Footprint < ApplicationRecord
   belongs_to :user
   belongs_to :work
-  validates :user_id, uniqueness: { scope: :work_id }
+  validates :user_id, presence: true, uniqueness: { scope: :work_id }
+  validates :work_id, presence: true
+  validates :counts, presence: true
 end

--- a/spec/factories/footprints.rb
+++ b/spec/factories/footprints.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :footprint do
     counts { 1 }
-    user { nil }
-    work { nil }
+    association :user, factory: :user, strategy: :create
+    association :work, factory: :work, strategy: :create
   end
 end

--- a/spec/models/footprint_spec.rb
+++ b/spec/models/footprint_spec.rb
@@ -1,5 +1,43 @@
 require 'rails_helper'
 
 RSpec.describe Footprint, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "Validations test" do
+    subject { footprint }
+
+    context "footprint has valid information" do
+      let(:footprint) { build(:footprint) }
+      it { is_expected.to be_valid }
+    end
+
+    context "footprint doesn't associated with a user" do
+      let(:footprint) { build(:footprint, user: nil) }
+      it { is_expected.not_to be_valid }
+    end
+
+    context "footprint doesn't associated with a work" do
+      let(:footprint) { build(:footprint, work: nil) }
+      it { is_expected.not_to be_valid }
+    end
+
+    context "counts of footprint is nil" do
+      let(:footprint) { build(:footprint, counts: nil) }
+      it { is_expected.not_to be_valid }
+    end
+
+    context "footprint has duplicate association" do
+      let(:user) { create(:user) }
+      let(:work) { create(:work) }
+      let!(:first_footprint) { create(:footprint, user: user, work: work) }
+      let(:footprint) { build(:footprint, user: user, work: work) }
+      it { is_expected.not_to be_valid }
+    end
+  end
+
+  describe "Default value's test" do
+    let(:footprint) { create(:footprint) }
+
+    it "value of counts is 1" do
+      expect(footprint.counts).to eq 1
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe User, type: :model do
 
     let(:user) { build(:user) }
 
-    context "user has valid imformation" do
+    context "user has valid information" do
       let(:user) { build(:user, username: "example", email: "test@exmpale.com") }
       it { is_expected.to be_valid }
     end


### PR DESCRIPTION
前回のPRで発行されたモデルの単体テストの追加した。 #82 
足跡モデルが持つバリデーションである各カラムの存在性や一意性、初期値の妥当性の単体テストを追加した。