### PR TITLE
足跡作成メソッドのテストの追加

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -13,6 +13,8 @@ class WorksController < ApplicationController
         illustrations: [photo_attachment: :blob],
       ]
     ).find(params[:id])
+    # ここで足跡を作成する。
+    # @work.create_footprint_by(current_user)
     @comment = current_user.comments.build
     @like = Like.new
     @liked = Like.find_by(user_id: current_user.id, work_id: params[:id])

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -76,4 +76,14 @@ class Work < ApplicationRecord
       notification.save if notification.valid?
     end
   end
+
+  def create_footprint_by(user)
+    if Footprint.find_by(user_id: user.id, work_id: id).present?
+      # 既に足跡が存在する場合。
+      # この場合はカウントの値に+1する
+    else
+      # 足跡が存在しない場合
+      # 足跡を新たに作成する
+    end
+  end
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -214,5 +214,49 @@ RSpec.describe Work, type: :model do
         end
       end
     end
+
+    describe "create_footprint_by" do
+      subject { work.create_footprint_by(user) }
+
+      context "footprint has not existed" do
+        let(:user) { create(:user) }
+        let(:work) { create(:work) }
+        let(:create_footprint) { Footprint.create(user_id: user.id, work_id: work.id) }
+        let(:footprint) { Footprint.find_by(user_id: user.id, work_id: work.id) }
+        it "create new footprint" do
+          is_expected.to equal create_footprint # メソッドを扱うことは、新しいオブジェクトを作成するのと同義
+        end
+
+        # 2回メソッドを利用すると足跡が増えてしまう。つまり、このテストは多分エラー
+        it "add new footprint object" do
+          is_expected.to change { Footprint.count }.by(1) # メソッドを扱うことでfootprintオブジェクトが1つ増えたということ
+        end
+
+        it "new footprint's counts is 1" do
+          expect(footprint.counts).to eq 1 # 新しいfootprintオブジェクトのカウントは1だということ
+        end
+      end
+
+      context "footprint has already created" do
+        let(:user) { create(:user) }
+        let(:work) { create(:work) }
+        let!(:footprint) { create(:footprint, user: user, work: work) }
+        let(:add_footprint) { "足跡を+１する動作" }
+        let(:exsiting_footprint) { Footprint.create(user_id: user.id, work_id: work.id) }
+        let!(:exsiting_footprints_counts) { footprint.counts }
+        it "add 1 to the counts" do
+          is_expected.to equal add_footprint # メソッドを扱うことは、足跡オブジェクトのカウントを+1するのと同義
+        end
+
+        it "add new footprint object" do
+          is_expected.not_to change { Footprint.count }.by(1) # メソッドを扱うことでfootprintオブジェクトの数は増えないということ。
+        end
+
+        # 2回メソッドを利用している為、カウントは+2されている筈
+        it "new footprint's counts is 1" do
+          expect(exsiting_footprint.counts).to eq exsiting_footprints_counts + 2
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
テスト駆動開発に即し、足跡作成メソッドの作成に伴い、先行してテストを作成した。
テストの内容は、以下の通り。
1. 既に足跡オブジェクトが存在するかどうかで条件分岐
2. 足跡オブジェクトが存在しない場合は、新たにオブジェクトが作成されること・その'counts'の値が1であること。
3. 足跡オブジェクトが存在する場合は、新たなオブジェクトが作成されないこと・その'counts'の値が+1されること。

この条件に従い、足跡作成メソッドを作成していく。