### PR TITLE
足跡オブジェクトを作成メソッドの追加

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -79,11 +79,11 @@ class Work < ApplicationRecord
 
   def create_footprint_by(user)
     if Footprint.find_by(user_id: user.id, work_id: id).present?
-      # 既に足跡が存在する場合。
-      # この場合はカウントの値に+1する
+      footprint = Footprint.find_by(user_id: user.id, work_id: id)
+      counts = footprint.counts
+      footprint.update_attribute(:counts, counts + 1)
     else
-      # 足跡が存在しない場合
-      # 足跡を新たに作成する
+      Footprint.create(user_id: user.id, work_id: id)
     end
   end
 end

--- a/db/migrate/20210603021223_create_footprints.rb
+++ b/db/migrate/20210603021223_create_footprints.rb
@@ -1,7 +1,7 @@
 class CreateFootprints < ActiveRecord::Migration[6.1]
   def change
     create_table :footprints do |t|
-      t.integer :counts, null: false, default: 0
+      t.integer :counts, null: false, default: 1
       t.references :user, null: false, foreign_key: true
       t.references :work, null: false, foreign_key: true
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,12 +59,12 @@ ActiveRecord::Schema.define(version: 2021_06_03_033849) do
   end
 
   create_table "footprints", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "counts", default: 0, null: false
+    t.integer "counts", default: 1, null: false
     t.bigint "user_id", null: false
     t.bigint "work_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["user_id", "work_id"], name: "index_footprints_on_user_id_and_work_id"
+    t.index ["user_id", "work_id"], name: "index_footprints_on_user_id_and_work_id", unique: true
     t.index ["user_id"], name: "index_footprints_on_user_id"
     t.index ["work_id"], name: "index_footprints_on_work_id"
   end


### PR DESCRIPTION
足跡オブジェクトを作成する、または既に作成されている場合は足跡オブジェクトのカウントを+1作成するメソッドを作成した。

現状では、メソッドを作成したのみであり、コントローラーには追加できていないので、実際に作品を閲覧した際に足跡オブジェクトの数値を変更する仕様を実現する。  #86 

また、前回作成したメソッドのテストが全てエラーとなっている為、これらのエラーをグリーンになるようテストの変更も行う。
#85 