### PR TITLE
create_footprint_byメソッドのテストをグリーンにする

### DIFF
--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -216,45 +216,37 @@ RSpec.describe Work, type: :model do
     end
 
     describe "create_footprint_by" do
-      subject { work.create_footprint_by(user) }
-
       context "footprint has not existed" do
+        let!(:footprint_count_before) { Footprint.count }
         let(:user) { create(:user) }
         let(:work) { create(:work) }
-        let(:create_footprint) { Footprint.create(user_id: user.id, work_id: work.id) }
         let(:footprint) { Footprint.find_by(user_id: user.id, work_id: work.id) }
-        it "create new footprint" do
-          is_expected.to equal create_footprint # メソッドを扱うことは、新しいオブジェクトを作成するのと同義
-        end
 
-        # 2回メソッドを利用すると足跡が増えてしまう。つまり、このテストは多分エラー
+        before { work.create_footprint_by(user) }
+
         it "add new footprint object" do
-          is_expected.to change { Footprint.count }.by(1) # メソッドを扱うことでfootprintオブジェクトが1つ増えたということ
+          expect(Footprint.count).to eq footprint_count_before + 1
         end
 
         it "new footprint's counts is 1" do
-          expect(footprint.counts).to eq 1 # 新しいfootprintオブジェクトのカウントは1だということ
+          expect(footprint.counts).to eq 1
         end
       end
 
       context "footprint has already created" do
+        before do
+          Footprint.create(user: user, work: work)
+          work.create_footprint_by(user)
+        end
+
         let(:user) { create(:user) }
         let(:work) { create(:work) }
-        let!(:footprint) { create(:footprint, user: user, work: work) }
-        let(:add_footprint) { "足跡を+１する動作" }
-        let(:exsiting_footprint) { Footprint.create(user_id: user.id, work_id: work.id) }
-        let!(:exsiting_footprints_counts) { footprint.counts }
-        it "add 1 to the counts" do
-          is_expected.to equal add_footprint # メソッドを扱うことは、足跡オブジェクトのカウントを+1するのと同義
-        end
+        let!(:footprint_count_before) { Footprint.count }
+        let(:footprint_finded) { Footprint.find_by(user_id: user.id, work_id: work.id) }
 
-        it "add new footprint object" do
-          is_expected.not_to change { Footprint.count }.by(1) # メソッドを扱うことでfootprintオブジェクトの数は増えないということ。
-        end
-
-        # 2回メソッドを利用している為、カウントは+2されている筈
-        it "new footprint's counts is 1" do
-          expect(exsiting_footprint.counts).to eq exsiting_footprints_counts + 2
+        it "does'nt add new footprint object" do
+          expect(Footprint.count).to eq footprint_count_before
+          expect(footprint_finded.counts).to eq 2
         end
       end
     end


### PR DESCRIPTION
テストをグリーンにする事で、メソッドの信頼性の向上をすることができた。
しかしながら、letやlet!, beforeなどの遅延評価を多用しており、可読性が低い。
この解決として新しくissueを作成した。 #88 