### PR TITLE
足跡オブジェクト作成メソッドをコントローラー内に追加

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -5,16 +5,18 @@ class WorksController < ApplicationController
   before_action :set_work_search, except: :index
 
   def show
-    @work = Work.includes(
-      [
-        :user,
-        comments: :user,
-        image_attachment: :blob,
-        illustrations: [photo_attachment: :blob],
-      ]
-    ).find(params[:id])
-    # ここで足跡を作成する。
-    # @work.create_footprint_by(current_user)
+    @work = Work.
+      # select( "works.*, SUM(footprints.counts) as total_footprints").
+      # joins(:footprints).
+      includes(
+        [
+          :user,
+          comments: :user,
+          image_attachment: :blob,
+          illustrations: [photo_attachment: :blob],
+        ]
+      ).find(params[:id])
+    @work.create_footprint_by(current_user)
     @comment = current_user.comments.build
     @like = Like.new
     @liked = Like.find_by(user_id: current_user.id, work_id: params[:id])

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -16,7 +16,7 @@
           <%= render "shared/comment_count", work: @work %>
         </div>
         <div class="work__footprints">
-          <i class="far fa-eye"></i><%= [*1..100].sample %>
+          <i class="far fa-eye"></i><%#= @work.total_footprints %>
         </div>
         <div class="timestamp">
           <%= time_ago_in_words(@work.created_at) %>前


### PR DESCRIPTION
`works_controller`へ`create_footprint_by`メソッドを追加する事で、自動的に足跡メソッドを追加できるようにした。
しかし以下のように、足跡の合計を選択するActiverecordを追加した際に、ユーザー画像の表示の際にエラーが発生する。
```ruby
@work = Work.
      select( "works.*, SUM(footprints.counts) as total_footprints").
      joins(:footprints).
      includes(
        [
          :user,
          comments: :user,
          image_attachment: :blob,
          illustrations: [photo_attachment: :blob],
        ]
      ).find(params[:id])
```
`@work.user.avatar`が`nil`になる、と言うエラーが発生している。
これまでは正常に表示できた事から、SQLが原因で問題が発生していると考える。