### PR TITLE
足跡オブジェクトを作成するタイミングの変更

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -6,8 +6,8 @@ class WorksController < ApplicationController
 
   def show
     @work = Work.
-      # select( "works.*, SUM(footprints.counts) as total_footprints").
-      # joins(:footprints).
+      select("works.*, SUM(footprints.counts) + 1 as total_footprints_count").
+      joins(:footprints).
       includes(
         [
           :user,

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1,5 +1,6 @@
 class Work < ApplicationRecord
   default_scope -> { order(created_at: :desc) }
+  after_create { Footprint.create(user_id: user_id, work_id: id, counts: 0) }
   has_one_attached :image
   belongs_to :user
   belongs_to :category

--- a/app/views/works/show.html.erb
+++ b/app/views/works/show.html.erb
@@ -16,7 +16,7 @@
           <%= render "shared/comment_count", work: @work %>
         </div>
         <div class="work__footprints">
-          <i class="far fa-eye"></i><%#= @work.total_footprints %>
+          <i class="far fa-eye"></i><%= @work.total_footprints_count %>
         </div>
         <div class="timestamp">
           <%= time_ago_in_words(@work.created_at) %>前


### PR DESCRIPTION
空の足跡オブジェクトを作品生成時に1つ作成する事にする。
それにより、作品を表示の際のクエリの発行数を減少させる事ができた。