### PR TITLE
設計変更に伴う足跡オブジェクトの作成に関するテスト

### DIFF
--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
       work.category_id = child_category.id
     end
 
+    after(:create) do |work|
+      Footprint.create(user_id: work.user.id, work_id: work.id, counts: 0)
+    end
+
     association :user, factory: :user, strategy: :create
     association :category, factory: :category, strategy: :create
     title { "TITLE" }

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -80,6 +80,19 @@ RSpec.describe Work, type: :model do
         expect(Comment.count).to eq count - 1
       end
     end
+
+    context "created work" do
+      let!(:count) { Footprint.count }
+      let!(:work) { create(:work) }
+      let(:footprint) { Footprint.find_by(user_id: work.user.id, work_id: work.id) }
+      it "create new footprint" do
+        expect(Footprint.count).to eq count + 1
+      end
+
+      it "counts of footprint is 0" do
+        expect(footprint.counts).to eq 0
+      end
+    end
   end
 
   describe "Method test" do
@@ -216,20 +229,23 @@ RSpec.describe Work, type: :model do
     end
 
     describe "create_footprint_by" do
-      context "footprint has not existed" do
+      context "create new footprint" do
         let!(:footprint_count_before) { Footprint.count }
-        let(:user) { create(:user) }
-        let(:work) { create(:work) }
-        let(:footprint) { Footprint.find_by(user_id: user.id, work_id: work.id) }
+        let!(:work) { create(:work, user: works_user) }
+        let(:other_user) { create(:user) }
+        let(:works_user) { create(:user) }
+        let(:own_footprint) { Footprint.find_by(user: works_user, work: work) }
+        let(:other_footprint) { Footprint.find_by(user: other_user, work: work) }
 
-        before { work.create_footprint_by(user) }
-
-        it "add new footprint object" do
+        it "add new footprint and a count to own footprint" do
           expect(Footprint.count).to eq footprint_count_before + 1
+          work.create_footprint_by(works_user)
+          expect(own_footprint.counts).to eq 1
         end
 
-        it "new footprint's counts is 1" do
-          expect(footprint.counts).to eq 1
+        it "add a count to other footprint" do
+          work.create_footprint_by(other_user)
+          expect(other_footprint.counts).to eq 1
         end
       end
 


### PR DESCRIPTION
仕様変更に伴い作品作成と同時に、モデルのコールバックを用いる事で`counts: 0`の足跡オブジェクトが作成される設計となった。
その変更に対応すべく、以下の変化を追加。
1. テスト環境においても作品作成と同時に足跡オブジェクトを作成させる
2. モデルのコールバックによる足跡オブジェクトの追加の単体テストを作成