### PR TITLE
閲覧数を確認する統合テストの追加

### DIFF
--- a/spec/system/works/works_footprint_spec.rb
+++ b/spec/system/works/works_footprint_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'Works footprint', type: :system, js: true do
+  let(:works_user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:another_user) { create(:user) }
+  let!(:work) { create(:work, user_id: works_user.id) }
+  let!(:footprint_by_another_user) { create(:footprint, work_id: work.id, user_id: another_user.id, counts: 10) }
+  let!(:footprint_by_other_user) { create(:footprint, work_id: work.id, user_id: other_user.id, counts: 10) }
+
+  it "check footprint counts of work" do
+    sign_in other_user
+    footprint_counts_by_other_user = Footprint.select(:counts).find_by(work_id: work.id, user_id: other_user.id).counts
+    expect do
+      visit work_path work
+      footprint_counts_by_other_user = Footprint.select(:counts).find_by(work_id: work.id, user_id: other_user.id).counts
+    end.to change { footprint_counts_by_other_user }.from(10).to(11)
+    expect(current_path).to eq work_path(work)
+    within("section.work--assessment__aside") do
+      expect(page).to have_selector "div.work__footprints",
+                                    text: "#{footprint_by_another_user.counts + footprint_by_other_user.counts + 1}"
+    end
+    visit current_path
+    within("section.work--assessment__aside") do
+      expect(page).to have_selector "div.work__footprints",
+                                    text: "#{footprint_by_another_user.counts + footprint_by_other_user.counts + 2}"
+    end
+  end
+end

--- a/spec/system/works/works_interface_spec.rb
+++ b/spec/system/works/works_interface_spec.rb
@@ -5,9 +5,6 @@ RSpec.describe 'Works interface', type: :system do
   let!(:works) { create_list(:work, 21, user: user) }
   let!(:current_work) { works[20] }
   let!(:illustrations) { create_list(:illustration, 5, work: current_work) }
-  # let(:footprint) do
-  #   Footprint.select("SUM(footprints.counts) as total_count").where(work_id: current_work.id)
-  # end
 
   it "check work feed has links correctly" do
     sign_in user
@@ -33,9 +30,6 @@ RSpec.describe 'Works interface', type: :system do
       expect(page).to have_selector "img[alt$='#{user.username}']"
       expect(page).to have_selector ".username", text: "#{current_work.user.username}"
     end
-    # within("section.work--assessment__aside") do
-    #   expect(page).to have_selector "div.work__footprints", text: "#{footprint.total_count}"
-    # end
     within(".work--all__information") do
       within(".work--main_info") do
         expect(page).to have_selector "h3", text: "#{current_work.title}"


### PR DESCRIPTION
これまでに拡張してきた、閲覧数を管理する足跡モデルの変化を確認する統合テストを追加した。