### PR TITLE
お気に入り作品表示におけるエラー対応

### DIFF
--- a/app/views/likes/_liked_works.html.erb
+++ b/app/views/likes/_liked_works.html.erb
@@ -13,10 +13,9 @@
 <div class="user--works__favorites">
   <% if @user.likes.present? %>
     <ol class="works">
-      <% @user.likes.each do |like| %>
-        <%= render like.work %>
-      <% end %>
+      <%= render @works %>
     </ol>
+    <%= paginate @works %>
   <% else %>
     <h4>いいねした作品がありません</h4>
   <% end %>


### PR DESCRIPTION
お気に入り作品表示の際に、コントローラーでの変数の代入方法の違いにより、エラーが発生していた。
その解決をすべく、コントローラーでの変数の代入方法の変更とテンプレートでの表示方法を変更した。