### PR TITLE
レコメンドアルゴリズムの作成

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -23,6 +23,20 @@ class WorksController < ApplicationController
         image_attachment: :blob,
         user: [avatar_attachment: :blob],
       ).where("works.id in (?)", [1, 2, 3, 4])
+      @recommended_works = Work.
+        where("works.id in (?)",
+          Footprint.
+            select(:work_id).
+            joins(:work).
+            where.not("works.user_id = footprints.user_id", ).
+            where("user_id in (?)",
+              User.
+                select(:id).
+                joins(:footprints).
+                where.not("users.id = ?", @work.user.id).
+                where("footprints.work_id = ?", @work.id)
+            )
+        )
     @comment = current_user.comments.build
     @like = Like.new
     @liked = Like.find_by(user_id: current_user.id, work_id: params[:id])


### PR DESCRIPTION
現状のレコメンドアルゴリズムは以下の通り。（`works/show`に遷移した際のコントローラーにて
1. まず`@work`を閲覧したユーザーのIDを取り出す。（以降は"`@work`閲覧ユーザー"とする
条件1：`@work`を閲覧したことのあるユーザーを指定
条件2：`@work`作成者本人は除外する

2. 次に`@work`閲覧ユーザーが閲覧した作品のidを選択する（以降は"`@work`閲覧ユーザーに閲覧された作品"とする。
条件1：`@work`閲覧ユーザーがこれまでに閲覧した作品を指定
条件2：`@work`閲覧ユーザー自身が作成した作品は取り除く　← 現状はこのアルゴリズムが成立しているか定かではない。

次のステップとしては、まずこのアルゴリズムが成立しているかどうか確認する。
以下のアルゴリズムを追加する。
「現在閲覧している作品の作品idを除去する」