### PR TITLE
Checkboxに条件分岐の追加

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -461,7 +461,7 @@ footer {
     .label--wrapper {
       display: flex;
       justify-content: space-between;
-      .in_label__checkbox {
+      .checkbox__work_concept {
         display: inline;
         width: 20%;
       }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -5,5 +5,6 @@ require("channels")
 require("bootstrap")
 require("jquery")
 require('./category')
+require('./form')
 require('./image')
 import "bootstrap"

--- a/app/javascript/packs/form.js
+++ b/app/javascript/packs/form.js
@@ -1,0 +1,13 @@
+$(function(){
+  // コンセプトcheckboxがチェックされたら、フォームをグレーアウトさせる
+  var conceptCheckbox = document.querySelector('.checkbox__work_concept')
+  var conceptForm = document.querySelector('#work_create_concept')
+  conceptCheckbox.addEventListener('change', function() {
+    var check = this.checked
+    if (check) {
+      conceptForm.value = 'checkされてますやん'
+    } else {
+      conceptForm.value = 'されてなーーい'
+    }
+  });
+});

--- a/app/views/works/_form.html.erb
+++ b/app/views/works/_form.html.erb
@@ -34,7 +34,7 @@
   <div class='label--wrapper'>
     <%= f.label :concept, "コンセプト", class: "f-control" %>
     <div class='width40 display_flex'>
-      <%= check_box_tag :pending, true, false, class: 'in_label__checkbox' %>
+      <%= check_box_tag :pending, true, false, class: 'checkbox__work_concept' %>
       <span>コンセプト未定</span>
     </div>
   </div>


### PR DESCRIPTION
#128 

次にグレーアウトさせるメソッドを追加する。

`app/javascripts/packs/form.js`
```javascript
$(function(){
  // コンセプトのcheckbox・フォームそれぞれを変数に格納
  var conceptCheckbox = document.querySelector('.checkbox__work_concept')
  var conceptForm = document.querySelector('#work_create_concept')
  // checkboxのcheckの変化で発火するようイベントを追加
  conceptCheckbox.addEventListener('change', function() {
    var check = this.checked
    if (check) { // checkboxがtrueの処理
      conceptForm.value = 'checkされてますやん'
    } else {       // checkboxがfalsseの処理
      conceptForm.value = 'されてなーーい'
    }
  });
});
```