### PR TITLE
グレーアウトさせる挙動の追加と、その上側の処理を追加

### DIFF
--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -1,7 +1,8 @@
 class WorksController < ApplicationController
   before_action :authenticate_user!, only: [:create, :destroy, :new, :show]
-  before_action :correct_user, only: [:destroy]
+  before_action :correct_user, only: :destroy
   before_action :set_categories, only: [:new, :create, :index, :search]
+  before_action :check_work_create_params, only: :create
   before_action :set_work_search, except: :index
 
   def show
@@ -93,6 +94,10 @@ class WorksController < ApplicationController
       :category_id,
       :parent_category_id,
     )
+  end
+
+  def check_work_create_params
+    params[:work_create][:concept] = 'コンセプト未定' if params[:pending]
   end
 
   def correct_user

--- a/app/javascript/packs/form.js
+++ b/app/javascript/packs/form.js
@@ -3,11 +3,7 @@ $(function(){
   var conceptCheckbox = document.querySelector('.checkbox__work_concept')
   var conceptForm = document.querySelector('#work_create_concept')
   conceptCheckbox.addEventListener('change', function() {
-    var check = this.checked
-    if (check) {
-      conceptForm.value = 'checkされてますやん'
-    } else {
-      conceptForm.value = 'されてなーーい'
-    }
+    if (this.checked) conceptForm.disabled = true;
+    else conceptForm.disabled = false;
   });
 });


### PR DESCRIPTION
#141 
JSでテキストボックスをグレーアウトさせ、
Rails側でチェックされた際に値を上書きするよう処理を追した。
これにより、checkboxがチェックされた場合は、'コンセプト未定'でparamsを上書きし、テキストボックスを入力不可にする。